### PR TITLE
Add Cypress end-to-end coverage

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "cypress";
+
+export default defineConfig({
+  e2e: {
+    baseUrl: "http://localhost:4321",
+    supportFile: "cypress/support/e2e.ts",
+    video: false,
+  },
+});

--- a/cypress/e2e/aktualnosci.cy.ts
+++ b/cypress/e2e/aktualnosci.cy.ts
@@ -1,0 +1,18 @@
+describe('Aktualności', () => {
+  it('osadza wtyczkę Facebooka z poprawnymi parametrami', () => {
+    cy.visitWithConsent('/aktualnosci');
+
+    cy.contains('h1', 'Aktualności').should('be.visible');
+    cy.get('#facebook-feed-iframe')
+      .should('be.visible')
+      .and('have.attr', 'title', 'Posty z Facebooka - TRolling Stones')
+      .and('have.attr', 'src')
+      .then((src) => {
+        expect(src).to.contain('facebook.com');
+        expect(src).to.match(/width=(?:[2-4]\d\d|500)/);
+        expect(src).to.contain('height=1200');
+      });
+
+    cy.get('#facebook-feed-iframe').should('have.attr', 'data-current-width');
+  });
+});

--- a/cypress/e2e/bio.cy.ts
+++ b/cypress/e2e/bio.cy.ts
@@ -1,0 +1,10 @@
+describe('Strona bio', () => {
+  it('prezentuje informacje o zespole', () => {
+    cy.visitWithConsent('/bio');
+
+    cy.contains('h1', 'Bio').should('be.visible');
+    cy.contains('Zespół TRolling Stones założyliśmy w 2015 roku').should('be.visible');
+    cy.contains('Od momentu założenia skład zmienił się tylko raz').should('be.visible');
+    cy.get('section').should('have.class', 'relative');
+  });
+});

--- a/cypress/e2e/galeria.cy.ts
+++ b/cypress/e2e/galeria.cy.ts
@@ -1,0 +1,22 @@
+describe('Galeria zdjęć', () => {
+  it('otwiera podgląd zdjęć w lightboxie', () => {
+    cy.visitWithConsent('/galeria');
+
+    cy.get('img[data-lightbox]').should('have.length', 5);
+    cy.get('img[data-lightbox]').first().then(($img) => {
+      const altText = $img.attr('alt');
+      cy.wrap($img).click();
+
+      cy.get('#lightbox-overlay').should('be.visible');
+      cy.get('#lightbox-image')
+        .should('have.attr', 'src')
+        .and('include', 'poster01');
+      if (altText) {
+        cy.get('#lightbox-caption').should('contain', altText);
+      }
+
+      cy.get('#lightbox-close').click();
+      cy.get('#lightbox-overlay').should('have.class', 'hidden');
+    });
+  });
+});

--- a/cypress/e2e/home.cy.ts
+++ b/cypress/e2e/home.cy.ts
@@ -1,0 +1,73 @@
+describe('Strona główna', () => {
+  it('wyświetla baner cookie i pozwala na akceptację', () => {
+    cy.visit('/');
+    cy.get('#cookie-banner', { timeout: 10000 }).should('be.visible');
+    cy.get('#cookie-accept').click();
+    cy.get('#cookie-banner').should('have.class', 'hidden');
+
+    cy.window().then((win) => {
+      expect(win.localStorage.getItem('cookieConsent')).to.equal('accepted');
+    });
+
+    cy.reload();
+    cy.get('#cookie-banner').should('have.class', 'hidden');
+  });
+
+  it('renderuje nagłówek, sekcję bohatera i linki społecznościowe', () => {
+    cy.visitWithConsent('/');
+
+    cy.get('header').within(() => {
+      cy.contains('a', 'TRolling Stones').should('have.attr', 'href', '/');
+      cy.contains('nav a', 'Koncerty').should('have.attr', 'href', '/koncerty');
+      cy.contains('nav a', 'Galeria').should('have.attr', 'href', '/galeria');
+      cy.contains('nav a', 'Aktualności').should('have.attr', 'href', '/aktualnosci');
+      cy.contains('nav a', 'Bio').should('have.attr', 'href', '/bio');
+      cy.contains('nav a', 'Skład').should('have.attr', 'href', '/sklad');
+      cy.contains('nav a', 'Kontakt').should('have.attr', 'href', '/kontakt');
+    });
+
+    cy.get('img[alt="TRolling Stones - Tribute to The Rolling Stones"]').should('be.visible');
+    cy.contains(
+      "Rock'n'roll z pulsującą energią. Sprawdź nasze koncerty, obejrzyj klipy i bądź na bieżąco z nowościami."
+    ).should('be.visible');
+
+    cy.contains('a', 'Zobacz koncerty').should('have.attr', 'href', '/koncerty');
+    cy.contains('a', 'Aktualności').should('have.attr', 'href', '/aktualnosci');
+
+    cy.contains('h2', 'Słuchaj i obserwuj')
+      .parent()
+      .find('li')
+      .should('have.length', 4)
+      .each(($li) => {
+        cy.wrap($li).find('a').should('have.attr', 'href');
+      });
+
+    cy.get('footer').contains('©').should('be.visible');
+  });
+
+  it('umożliwia przełączanie klipów w karuzeli YouTube', () => {
+    cy.visitWithConsent('/');
+
+    cy.get('#yt-container iframe').should('exist');
+    cy.get('#yt-container iframe')
+      .invoke('attr', 'src')
+      .then((initialSrc) => {
+        expect(initialSrc).to.contain('youtube');
+
+        cy.get('button#next').click();
+        cy.get('#yt-container iframe')
+          .invoke('attr', 'src')
+          .should((nextSrc) => {
+            expect(nextSrc).to.contain('youtube');
+            expect(nextSrc).to.not.equal(initialSrc);
+          });
+
+        cy.get('button#prev').click();
+        cy.get('#yt-container iframe')
+          .invoke('attr', 'src')
+          .should((srcAfterPrev) => {
+            expect(srcAfterPrev).to.equal(initialSrc);
+          });
+      });
+  });
+});

--- a/cypress/e2e/koncerty.cy.ts
+++ b/cypress/e2e/koncerty.cy.ts
@@ -1,0 +1,11 @@
+describe('Strona koncertów', () => {
+  it('pokazuje najbliższe wydarzenia', () => {
+    cy.visitWithConsent('/koncerty');
+
+    cy.contains('h1', 'Koncerty').should('be.visible');
+    cy.contains('Nadchodzące daty występów.').should('be.visible');
+    cy.contains('6.12.2025').should('be.visible');
+    cy.contains('Gdynia - Blues Club').should('be.visible');
+    cy.contains('Sprzedaż wkrótce').should('be.visible');
+  });
+});

--- a/cypress/e2e/kontakt.cy.ts
+++ b/cypress/e2e/kontakt.cy.ts
@@ -1,0 +1,24 @@
+describe('Strona kontaktowa', () => {
+  it('prezentuje dane kontaktowe i linki społecznościowe', () => {
+    cy.visitWithConsent('/kontakt');
+
+    cy.contains('h1', 'Kontakt').should('be.visible');
+    cy.contains('Manager Daniel Macidłowski').should('be.visible');
+    cy.contains('a', 'booking@trollingstones.pl')
+      .should('have.attr', 'href')
+      .and('include', 'mailto:booking@trollingstones.pl');
+    cy.contains('a', '+48 509 243 245')
+      .should('have.attr', 'href')
+      .and('include', 'tel:+48509243245');
+    cy.contains('a', 'Rider techniczny (PDF)')
+      .should('have.attr', 'href')
+      .and('include', '/assets/Rider-techniczy-Trolling-Stones-25.03.2025.pdf');
+
+    cy.contains('h2', 'Social media').next('ul').find('li').should('have.length', 4);
+
+    cy.get('img[data-lightbox]').first().click();
+    cy.get('#lightbox-overlay').should('be.visible');
+    cy.get('body').type('{esc}');
+    cy.get('#lightbox-overlay').should('have.class', 'hidden');
+  });
+});

--- a/cypress/e2e/sklad.cy.ts
+++ b/cypress/e2e/sklad.cy.ts
@@ -1,0 +1,16 @@
+describe('Skład zespołu', () => {
+  it('wyświetla wszystkich członków i obsługuje podgląd zdjęć', () => {
+    cy.visitWithConsent('/sklad');
+
+    cy.contains('h1', 'Skład').should('be.visible');
+    cy.get('img[data-lightbox]').should('have.length', 6);
+    cy.contains("Artur 'Walec' Dembicki - gitara prowadząca").should('be.visible');
+    cy.contains("Zbigniew 'Zbylon' Kalinowski - wokal, harmonijka").should('be.visible');
+
+    cy.get('img[data-lightbox]').last().click();
+    cy.get('#lightbox-overlay').should('be.visible');
+    cy.get('#lightbox-image').should('have.attr', 'src').and('include', '/images/members/');
+    cy.get('#lightbox-backdrop').click({ force: true });
+    cy.get('#lightbox-overlay').should('have.class', 'hidden');
+  });
+});

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -1,0 +1,28 @@
+/// <reference types="cypress" />
+
+declare global {
+  namespace Cypress {
+    interface Chainable {
+      /**
+       * Visit a page with the cookie consent already accepted to avoid the banner in tests.
+       */
+      visitWithConsent(url: string, options?: Partial<Cypress.VisitOptions>): Chainable<Cypress.AUTWindow>;
+    }
+  }
+}
+
+Cypress.Commands.add('visitWithConsent', (url: string, options: Partial<Cypress.VisitOptions> = {}) => {
+  const originalOnBeforeLoad = options.onBeforeLoad;
+
+  cy.visit(url, {
+    ...options,
+    onBeforeLoad(win) {
+      win.localStorage.setItem('cookieConsent', 'accepted');
+      if (originalOnBeforeLoad) {
+        originalOnBeforeLoad(win);
+      }
+    },
+  });
+});
+
+export {};

--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -1,0 +1,6 @@
+import './commands';
+
+beforeEach(() => {
+  cy.clearCookies();
+  cy.clearLocalStorage();
+});

--- a/cypress/tsconfig.json
+++ b/cypress/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "types": ["cypress"],
+    "isolatedModules": false
+  },
+  "include": ["../node_modules/cypress", "./**/*.ts"]
+}

--- a/package.json
+++ b/package.json
@@ -9,16 +9,21 @@
     "build": "astro build",
     "preview": "astro preview",
     "preview:lan": "astro preview --host",
-    "astro": "astro"
+    "astro": "astro",
+    "cy:run": "cypress run",
+    "cy:open": "cypress open",
+    "test:e2e": "start-server-and-test dev http://localhost:4321 cy:run"
   },
   "dependencies": {
-    "astro": "^5.13.7",
-    "@astrojs/sitemap": "^3.2.0"
+    "@astrojs/sitemap": "^3.2.0",
+    "astro": "^5.13.7"
   },
   "devDependencies": {
     "@astrojs/tailwind": "^6.0.2",
     "autoprefixer": "^10.4.20",
+    "cypress": "13.13.0",
     "postcss": "^8.4.47",
+    "start-server-and-test": "2.0.3",
     "tailwindcss": "^3.4.14",
     "typescript": "^5.6.2"
   }


### PR DESCRIPTION
## Summary
- add a Cypress configuration and shared helpers for clearing storage and visiting pages with cookie consent
- cover the home, news, concerts, gallery, contact, bio and line-up pages with end-to-end checks for banners, media widgets and lightbox interactions
- expose npm scripts for running Cypress locally together with the Astro dev server

## Testing
- npm run test:e2e *(fails: start-server-and-test is unavailable because Cypress could not be installed behind the proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68c86c33b93883318c3b9699a97dd6d8